### PR TITLE
shadow send disabled fields

### DIFF
--- a/lib/active_dry_form/input.rb
+++ b/lib/active_dry_form/input.rb
@@ -41,6 +41,7 @@ module ActiveDryForm
         [
           label_last ? input : label,
           label_last ? label : input,
+          (@builder.input_hidden(@method) if input_opts[:disabled]),
           hint_text,
           error_text,
         ].compact.join.html_safe

--- a/lib/active_dry_form/input.rb
+++ b/lib/active_dry_form/input.rb
@@ -41,7 +41,6 @@ module ActiveDryForm
         [
           label_last ? input : label,
           label_last ? label : input,
-          (@builder.input_hidden(@method) if input_opts[:disabled]),
           hint_text,
           error_text,
         ].compact.join.html_safe

--- a/spec/active_dry_form/form_helper_spec.rb
+++ b/spec/active_dry_form/form_helper_spec.rb
@@ -54,14 +54,14 @@ RSpec.describe ActiveDryForm::FormHelper do
       expect(html).to include('user is read only')
     end
 
-    it 'shows disabled field' do
+    it 'shows readonly field' do
       form = UserForm.new(record: user)
 
-      html = context.active_dry_form_for(form) { |f| f.input :name, disabled: true }
+      html = context.active_dry_form_for(form) { |f| f.input :name, readonly: true }
 
-      expect(html).to include('type="hidden"')
-      expect(html).to include('value="Ivan"').twice
-      expect(html).to include('name="user[name]"').twice
+      expect(html).to include('readonly')
+      expect(html).to include('value="Ivan"')
+      expect(html).to include('name="user[name]"')
     end
   end
 

--- a/spec/active_dry_form/form_helper_spec.rb
+++ b/spec/active_dry_form/form_helper_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe ActiveDryForm::FormHelper do
 
       expect(html).to include('user is read only')
     end
+
+    it 'shows disabled field' do
+      form = UserForm.new(record: user)
+
+      html = context.active_dry_form_for(form) { |f| f.input :name, disabled: true }
+
+      expect(html).to include('type="hidden"')
+      expect(html).to include('value="Ivan"').twice
+      expect(html).to include('name="user[name]"').twice
+    end
   end
 
   context 'when single nested form rendered' do


### PR DESCRIPTION
```ruby
module Purchases
  module Submit
    class Form
    ...
    required(:supplier_id).filled(:integer)
    ...
  end
end
```

```slim
= f.input_autocomplete :supplier_id, {}, { disabled: form.persisted? }, association: :supplier
```