### PR TITLE
fix: required field

### DIFF
--- a/lib/active_dry_form/builder.rb
+++ b/lib/active_dry_form/builder.rb
@@ -29,8 +29,8 @@ module ActiveDryForm
     end
 
     def input_select(method, collection, options = {}, html_options = {}) # rubocop:disable Gp/OptArgParameters
-      dry_tag = ActiveDryForm::Input.new(self, __method__, method, options)
-      dry_tag.wrap_tag select(method, collection, dry_tag.input_opts, html_options.merge('data-controller': 'select-tag'))
+      dry_tag = ActiveDryForm::Input.new(self, __method__, method, html_options)
+      dry_tag.wrap_tag select(method, collection, options, dry_tag.input_opts.merge('data-controller': 'select-tag'))
     end
 
     def input_checkbox_inline(method, options = {})

--- a/lib/active_dry_form/input.rb
+++ b/lib/active_dry_form/input.rb
@@ -21,7 +21,9 @@ module ActiveDryForm
       @label_text = options[:label_text]
       @hint_text = options[:hint]
       @input_opts = options.except(:label, :hint, :label_text)
-      @input_opts[:required] = true if @input_opts[:required].nil? && info[:required]
+
+      @required = info[:required] || @input_opts[:required]
+      @input_opts[:required] = true if @required
     end
 
     def css_classes
@@ -30,7 +32,7 @@ module ActiveDryForm
         @method_type,
         @input_type,
         @method,
-        ('required' if @input_opts[:required]),
+        ('required' if @required),
         ('error' if error?(@method)),
       ].compact
     end

--- a/lib/active_dry_form/input.rb
+++ b/lib/active_dry_form/input.rb
@@ -16,13 +16,12 @@ module ActiveDryForm
       end
 
       @input_type = (Array(info[:type]) - %w[null]).first
-      @required = info[:required]
 
       @label_opts = options[:label]
       @label_text = options[:label_text]
       @hint_text = options[:hint]
       @input_opts = options.except(:label, :hint, :label_text)
-      @input_opts[:required] = true if @required
+      @input_opts[:required] = true if @input_opts[:required].nil? && info[:required]
     end
 
     def css_classes
@@ -31,7 +30,7 @@ module ActiveDryForm
         @method_type,
         @input_type,
         @method,
-        ('required' if @required),
+        ('required' if @input_opts[:required]),
         ('error' if error?(@method)),
       ].compact
     end

--- a/spec/active_dry_form/form_helper_spec.rb
+++ b/spec/active_dry_form/form_helper_spec.rb
@@ -22,10 +22,6 @@ module StubUrlHelpers
 
 end
 
-def clean_html(html)
-  html.delete("\n").gsub(/>\s+</, '><')
-end
-
 RSpec.describe ActiveDryForm::FormHelper do
   let(:controller) { ActionView::TestCase::TestController.new }
   let(:context) { controller.view_context.extend(StubUrlHelpers) }
@@ -33,142 +29,266 @@ RSpec.describe ActiveDryForm::FormHelper do
   let(:user) { User.create!(name: 'Ivan') }
 
   context 'when plain form rendered' do
-    it 'shows fields' do
+    it 'renders input with additional attributes' do
       form = UserForm.new(record: user)
-      html = context.active_dry_form_for(form) { |f| f.input :name }
+      html = context.active_dry_form_for(form) { |f| f.input :name, readonly: true }
 
-      expect(html).to include('required')
-      expect(html).to include('value="Ivan"')
-      expect(html).to include('name="user[name]"')
+      expected_html = <<-HTML
+        <div class="input input string name required">
+          <label for="user_name">User Name</label>
+          <input readonly="readonly" required="required" type="text" value="Ivan" name="user[name]" id="user_name" />
+        </div>
+      HTML
+
+      expect(html).to include_html(expected_html)
     end
 
-    it 'shows various input types' do
-      form = FieldVarietyForm.new
-      html =
-        context.active_dry_form_for(form) do |f|
-          concat f.input_hidden :id
-          concat f.input :age
-          concat f.input :is_retail
-          concat f.input :password
-          concat f.input :email
-          concat f.input :phone
-          concat f.input :url
-          concat f.input_text :about
-          concat f.input :birthday
-          concat f.input :call_on
-        end
-
-      expect(html).to include('type="hidden"')
-      expect(html).to include('type="number"')
-      expect(html).to include('type="checkbox"')
-      expect(html).to include('type="password"')
-      expect(html).to include('type="email"')
-      expect(html).to include('type="tel"')
-      expect(html).to include('type="url"')
-      expect(html).to include('textarea')
-      expect(html).to include('flatpickr')
-      expect(html).to include('data-flatpickr-enable-time')
-    end
-
-    it 'shows validation errors' do
+    it 'renders input with validation errors' do
       form = UserForm.new(record: user, params: { user: { name: '' } })
       form.update
 
       html = context.active_dry_form_for(form) { |f| f.input :name }
 
-      expect(html).to include('должно быть заполнено')
-    end
-
-    it 'shows base validation errors' do
-      form = BaseValidationForm.new(record: user, params: { user: { name: 'Maria' } })
-      form.update
-
-      html = context.active_dry_form_for(form) { |f| f.input :name }
-
-      expect(html).to include('user is read only')
-    end
-
-    it 'shows readonly field' do
-      form = UserForm.new(record: user)
-
-      html = context.active_dry_form_for(form) { |f| f.input :name, readonly: true }
-
-      expect(html).to include('readonly')
-      expect(html).to include('value="Ivan"')
-      expect(html).to include('name="user[name]"')
-    end
-
-    it 'renders select' do
-      form = UserForm.new(record: user)
-      html =
-        context.active_dry_form_for(form) do |f|
-          f.input_select :name, %w[Ivan Boris], { include_blank: 'A boy has no name' }
-        end
-
-      expected_html = <<~HTML
-        <div class="input input_select string name required">
+      expected_html = <<-HTML
+        <div class="input input string name required error">
           <label for="user_name">User Name</label>
-          <select required="required" data-controller="select-tag" name="user[name]" id="user_name">
-            <option value="">A boy has no name</option>
-            <option selected="selected" value="Ivan">Ivan</option>
-            <option value="Boris">Boris</option>
-          </select>
+          <input required="required" type="text" name="user[name]" id="user_name" />
+          <div class="form-error is-visible">должно быть заполнено</div>
         </div>
       HTML
 
-      expect(clean_html(html)).to include(clean_html(expected_html))
+      expect(html).to include_html(expected_html)
     end
 
-    context 'when required explicitly disabled' do
-      it 'renders select tag without required attribute and wrapper class' do
-        form = UserForm.new(record: user)
+    it 'renders base validation errors' do
+      form = BaseValidationForm.new(record: user, params: { user: { name: 'Maria' } })
+      form.update
+
+      html = context.active_dry_form_for(form) { |f| concat f.input :name }
+
+      expected_html = <<-HTML
+        <div class="callout alert form-base-error">
+          <ul><li>user is read only</li></ul>
+        </div>
+        <div class="input input string name">
+          <label for="user_name">User Name</label>
+          <input type="text" value="Maria" name="user[name]" id="user_name" />
+        </div>
+      HTML
+
+      expect(html).to include_html(expected_html)
+    end
+
+    describe 'various input types' do
+      let(:form) { FieldVarietyForm.new }
+
+      it 'renders text input' do
+        html = context.active_dry_form_for(form) { |f| f.input :name }
+        expected_html = <<-HTML
+          <div class="input input string name">
+            <label for="user_name">User Name</label>
+            <input type="text" name="user[name]" id="user_name" />
+          </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders hidden input' do
+        html = context.active_dry_form_for(form) { |f| f.input_hidden :id }
+        expected_html = <<-HTML
+        <input autocomplete="off" type="hidden" name="user[id]" id="user_id" />
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders integer input' do
+        html = context.active_dry_form_for(form) { |f| f.input :age }
+        expected_html = <<-HTML
+        <div class="input input integer age">
+          <label for="user_age">User Age</label>
+          <input type="number" name="user[age]" id="user_age" />
+        </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders boolean checkbox' do
+        html = context.active_dry_form_for(form) { |f| f.input :is_retail }
+        expected_html = <<-HTML
+        <div class="input input boolean is_retail">
+          <label for="user_is_retail">User Is Retail</label>
+          <input name="user[is_retail]" type="hidden" value="0" autocomplete="off" />
+          <input type="checkbox" value="1" name="user[is_retail]" id="user_is_retail" />
+        </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders password input' do
+        html = context.active_dry_form_for(form) { |f| f.input :password }
+        expected_html = <<-HTML
+        <div class="input input string password">
+          <label for="user_password">User Password</label>
+          <input type="password" name="user[password]" id="user_password" />
+        </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders email input' do
+        html = context.active_dry_form_for(form) { |f| f.input :email }
+        expected_html = <<-HTML
+        <div class="input input string email">
+          <label for="user_email">User Email</label>
+          <input type="email" name="user[email]" id="user_email" />
+        </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders tel input' do
+        html = context.active_dry_form_for(form) { |f| f.input :phone }
+        expected_html = <<-HTML
+        <div class="input input string phone">
+          <label for="user_phone">User Phone</label>
+          <input type="tel" name="user[phone]" id="user_phone" />
+        </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders url input' do
+        html = context.active_dry_form_for(form) { |f| f.input :url }
+        expected_html = <<-HTML
+        <div class="input input string url">
+          <label for="user_url">User Url</label>
+          <input type="url" name="user[url]" id="user_url" />
+        </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders textarea' do
+        html = context.active_dry_form_for(form) { |f| f.input_text :about }
+        expected_html = <<-HTML
+        <div class="input input_text string about">
+          <label for="user_about">User About</label>
+          <textarea name="user[about]" id="user_about"></textarea>
+        </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders date input' do
+        html = context.active_dry_form_for(form) { |f| f.input :birthday }
+        expected_html = <<-HTML
+        <div class="input input date birthday">
+          <label for="user_birthday">User Birthday</label>
+            <input data-controller="flatpickr" type="text" name="user[birthday]" id="user_birthday" />
+        </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders date_time input' do
+        html = context.active_dry_form_for(form) { |f| f.input :call_on }
+        expected_html = <<-HTML
+        <div class="input input date-time call_on">
+          <label for="user_call_on">User Call On</label>
+            <input data-controller="flatpickr" data-flatpickr-enable-time="true" type="text" name="user[call_on]" id="user_call_on" />
+        </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders select' do
         html =
           context.active_dry_form_for(form) do |f|
-            f.input_select :name, %w[Ivan], {}, { required: false }
+            f.input_select :name, %w[Ivan Boris], { include_blank: 'A boy has no name' }
           end
 
-        expected_html = <<~HTML
+        expected_html = <<-HTML
           <div class="input input_select string name">
             <label for="user_name">User Name</label>
             <select data-controller="select-tag" name="user[name]" id="user_name">
-              <option selected="selected" value="Ivan">Ivan</option>
+              <option value="">A boy has no name</option>
+              <option value="Ivan">Ivan</option>
+              <option value="Boris">Boris</option>
             </select>
           </div>
         HTML
 
-        expect(clean_html(html)).to include(clean_html(expected_html))
+        expect(html).to include_html(expected_html)
       end
+    end
 
-      it 'renders input tag without required attribute and wrapper class' do
+    context 'when required explicitly enabled for optional field' do
+      it 'renders select with required attribute and wrapper class' do
         form = UserForm.new(record: user)
-        html = context.active_dry_form_for(form) { |f| f.input :name, required: false }
+        html =
+          context.active_dry_form_for(form) do |f|
+            f.input_select :second_name, %w[Ivan], {}, { required: true }
+          end
 
-        expected_html = <<~HTML
-          <div class="input input string name">
-            <label for="user_name">User Name</label>
-            <input type="text" value="Ivan" name="user[name]" id="user_name" />
+        expected_html = <<-HTML
+          <div class="input input_select string second_name required">
+            <label for="user_second_name">User Second Name</label>
+            <select required="required" data-controller="select-tag" name="user[second_name]" id="user_second_name"><option value="" label=" "></option>
+              <option value="Ivan">Ivan</option>
+            </select>
           </div>
         HTML
 
-        expect(clean_html(html)).to include(clean_html(expected_html))
+        expect(html).to include_html(expected_html)
+      end
+
+      it 'renders text input with required attribute and wrapper class' do
+        form = UserForm.new(record: user)
+        html = context.active_dry_form_for(form) { |f| f.input :second_name, required: true }
+
+        expected_html = <<-HTML
+          <div class="input input string second_name required">
+            <label for="user_second_name">User Second Name</label>
+
+            <input required="required" type="text" name="user[second_name]" id="user_second_name" />
+          </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
       end
     end
   end
 
   context 'when single nested form rendered' do
-    it 'shows nested fields' do
+    it 'renders input' do
       form = NestedHasOneForm.new(record: user)
       html =
         context.active_dry_form_for(form) do |f|
           f.fields_for(:personal_info) { |sf| sf.input(:age) }
         end
 
-      expect(html).to include('required')
-      expect(html).to include('type="number"')
-      expect(html).to include('name="user[personal_info][age]"')
+      expected_html = <<-HTML
+        <div class="input input integer age required">
+          <label for="user_personal_info_age">Perconal Info Age</label>
+          <input required="required" type="number" name="user[personal_info][age]" id="user_personal_info_age" />
+        </div>
+      HTML
+
+      expect(html).to include_html(expected_html)
     end
 
-    it 'shows nested errors' do
+    it 'renders input with errors' do
       form = NestedHasOneForm.new(record: user, params: { user: { personal_info: { age: '' } } })
       form.update
       html =
@@ -176,14 +296,22 @@ RSpec.describe ActiveDryForm::FormHelper do
           f.fields_for(:personal_info) { |sf| sf.input(:age) }
         end
 
-      expect(html).to include('должно быть заполнено')
+      expected_html = <<-HTML
+        <div class="input input integer age required error">
+          <label for="user_personal_info_age">Perconal Info Age</label>
+          <input required="required" type="number" name="user[personal_info][age]" id="user_personal_info_age" />
+          <div class="form-error is-visible">должно быть заполнено</div>
+        </div>
+      HTML
+
+      expect(html).to include_html(expected_html)
     end
   end
 
   context 'when multiple nested form rendered' do
     before(:each) { user.bookmarks.build }
 
-    it 'shows nested fields' do
+    it 'renders input' do
       form = NestedHasManyForm.new(record: user)
       html =
         context.active_dry_form_for(form) do |f|
@@ -192,12 +320,17 @@ RSpec.describe ActiveDryForm::FormHelper do
           end
         end
 
-      expect(html).to include('required')
-      expect(html).to include('type="url"')
-      expect(html).to include('name="user[bookmarks][][url]"')
+      expected_html = <<-HTML
+        <div class="input input string url required">
+          <label for="user_bookmarks__url">Bookmarks URL</label>
+          <input required="required" type="url" name="user[bookmarks][][url]" id="user_bookmarks__url" />
+        </div>
+      HTML
+
+      expect(html).to include_html(expected_html)
     end
 
-    it 'shows nested errors' do
+    it 'renders input with errors' do
       bookmarks_attributes = [
         { url: '' },
       ]
@@ -210,7 +343,15 @@ RSpec.describe ActiveDryForm::FormHelper do
           end
         end
 
-      expect(html).to include('должно быть заполнено')
+      expected_html = <<-HTML
+        <div class="input input string url required error">
+          <label for="user_bookmarks__url">Bookmarks URL</label>
+          <input required="required" type="url" name="user[bookmarks][][url]" id="user_bookmarks__url" />
+          <div class="form-error is-visible">должно быть заполнено</div>
+        </div>
+      HTML
+
+      expect(html).to include_html(expected_html)
     end
   end
 end

--- a/spec/active_dry_form/form_helper_spec.rb
+++ b/spec/active_dry_form/form_helper_spec.rb
@@ -92,6 +92,42 @@ RSpec.describe ActiveDryForm::FormHelper do
       expect(html).to include('value="Ivan"')
       expect(html).to include('name="user[name]"')
     end
+
+    it 'does not show `required` attribute and class name of `input` if it is explicity set to `false`' do
+      form = UserForm.new(record: user)
+      html =
+        context.active_dry_form_for(form) do |f|
+          f.input :name, required: false
+        end
+
+      expect(html).not_to include('required')
+    end
+
+    it 'shows select with `required` attribute' do
+      form = UserForm.new(record: user)
+      html =
+        context.active_dry_form_for(form) do |f|
+          f.input_select :name, %w[Ivan Boris], { include_blank: 'A boy has no name' }
+        end
+
+      expect(html).to include('<select')
+      expect(html).to include('name="user[name]"')
+      expect(html).to include('required')
+      expect(html).to include('<option value="">A boy has no name</option>')
+      expect(html).to include('<option selected="selected" value="Ivan">Ivan</option>')
+      expect(html).to include('<option value="Boris">Boris</option>')
+    end
+
+    it 'does not show `required` attribute and class name of `select` if it is explicity set to `false`' do
+      form = UserForm.new(record: user)
+      html =
+        context.active_dry_form_for(form) do |f|
+          f.input_select :name, %w[Ivan], {}, { required: false }
+        end
+
+      expect(html).to include('<select')
+      expect(html).not_to include('required')
+    end
   end
 
   context 'when single nested form rendered' do

--- a/spec/app/en.yml
+++ b/spec/app/en.yml
@@ -3,3 +3,17 @@ en:
     attributes:
       user:
         name: User Name
+        second_name: User Second Name
+        age: User Age
+        is_retail: User Is Retail
+        password: User Password
+        email: User Email
+        phone: User Phone
+        url: User Url
+        about: User About
+        birthday: User Birthday
+        call_on: User Call On
+      personal_info:
+        age: Perconal Info Age
+      bookmarks:
+        url: Bookmarks URL

--- a/spec/app/en.yml
+++ b/spec/app/en.yml
@@ -1,0 +1,5 @@
+en:
+  activerecord:
+    attributes:
+      user:
+        name: User Name

--- a/spec/app/field_variety_form.rb
+++ b/spec/app/field_variety_form.rb
@@ -5,6 +5,7 @@ class FieldVarietyForm < ActiveDryForm::Form
   fields(:user) do
     params do
       optional(:id).maybe(:integer)
+      optional(:name).maybe(:string)
       optional(:age).maybe(:integer)
       optional(:is_retail).maybe(:bool)
       optional(:password).maybe(:string)

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :include_html do |expected|
+  def clean_html(html)
+    html.gsub(/>\s+</, '><').strip
+  end
+
+  match do |actual|
+    clean_html(actual).include?(clean_html(expected))
+  end
+end


### PR DESCRIPTION
У `input_select` не ставился атрибут `required`, поэтому не работала html5 валидация в селектах. В `ActiveDryForm::Builder` немного неправильно передавались опции в `select()`, поправил.

Заодно сделал, чтобы при передаче опции `required` звездочка во враппере и атрибут `required` у инпута ставились/убирались согласованно вместе.