### PR TITLE
feat: force set `include_blank` to `true` when `required = true`

### DIFF
--- a/lib/active_dry_form/builder.rb
+++ b/lib/active_dry_form/builder.rb
@@ -30,7 +30,15 @@ module ActiveDryForm
 
     def input_select(method, collection, options = {}, html_options = {}) # rubocop:disable Gp/OptArgParameters
       dry_tag = ActiveDryForm::Input.new(self, __method__, method, html_options)
-      dry_tag.wrap_tag select(method, collection, options, dry_tag.input_opts.merge('data-controller': 'select-tag'))
+
+      html_options = dry_tag.input_opts.merge('data-controller': 'select-tag')
+      # Add blank `option` element instead of raising an error
+      # https://github.com/rails/rails/blob/v7.0.3/actionview/lib/action_view/helpers/tags/base.rb#L128
+      if placeholder_required?(html_options) && !options[:prompt]
+        options[:include_blank] ||= true
+      end
+
+      dry_tag.wrap_tag select(method, collection, options, html_options)
     end
 
     def input_checkbox_inline(method, options = {})
@@ -90,6 +98,11 @@ module ActiveDryForm
         end
         output
       end
+    end
+
+    # From https://github.com/rails/rails/blob/v7.0.3/actionview/lib/action_view/helpers/tags/base.rb#L142
+    private def placeholder_required?(html_options)
+      html_options[:required] && !html_options[:multiple] && html_options.fetch(:size, 1).to_i == 1
     end
 
   end

--- a/spec/active_dry_form/form_helper_spec.rb
+++ b/spec/active_dry_form/form_helper_spec.rb
@@ -231,6 +231,26 @@ RSpec.describe ActiveDryForm::FormHelper do
 
         expect(html).to include_html(expected_html)
       end
+
+      it 'renders select with forced `include_blank = true` when `required = true`' do
+        html =
+          context.active_dry_form_for(form) do |f|
+            f.input_select :name, %w[Ivan Boris], { include_blank: false }, { required: true }
+          end
+
+        expected_html = <<-HTML
+          <div class="input input_select string name required">
+            <label for="user_name">User Name</label>
+            <select required="required" data-controller="select-tag" name="user[name]" id="user_name">
+              <option value="" label=" "></option>
+              <option value="Ivan">Ivan</option>
+              <option value="Boris">Boris</option>
+            </select>
+          </div>
+        HTML
+
+        expect(html).to include_html(expected_html)
+      end
     end
 
     context 'when required explicitly enabled for optional field' do


### PR DESCRIPTION
В спецификации HTML [указано](https://html.spec.whatwg.org/multipage/form-elements.html#attr-select-required), что если у `select` указан атрибут `required`, нет `multiple` и `size = 1` (по умолчанию), то должен быть пустой тег `option`. Т.е. нельзя сделать так: `select_tag :name, options, { include_blank: false }, { required: true }`. Рельсы [выкидывают ArgumentError](https://github.com/rails/rails/blob/v7.0.3/actionview/lib/action_view/helpers/tags/base.rb#L128) в таком случае и в gp есть места, где эта ошибка появляется из-за последнего обновления, раньше у селекта просто не ставился `required`.

В этом PR сделал, чтобы при одновременных `required = true` и `include_blank = false`, `include_blank` становился `true`, чтобы соответствовать спецификации и не падать с ошибкой, правда такое поведение отличается от рельсового `select`, возможно лучше оставить как есть и хорошо посмотреть на такие места в gp.