### PR TITLE
Validation::Result#data

### DIFF
--- a/lib/active_dry_form/form.rb
+++ b/lib/active_dry_form/form.rb
@@ -85,6 +85,10 @@ module ActiveDryForm
       @validator ||= self.class::CURRENT_CONTRACT.call(attributes, { form: self, record: record })
     end
 
+    def data
+      validator.values.data
+    end
+
     def errors
       return {} unless @validator
 

--- a/spec/app/custom_contract_form.rb
+++ b/spec/app/custom_contract_form.rb
@@ -13,7 +13,7 @@ class CustomContractForm < ApplicationForm
   end
 
   action def create
-    record = User.create!(validator.to_h)
+    record = User.create!(data)
     Success(record)
   end
 

--- a/spec/app/nested_has_many_form.rb
+++ b/spec/app/nested_has_many_form.rb
@@ -24,7 +24,7 @@ class NestedHasManyForm < ActiveDryForm::Form
   end
 
   action def update
-    record.attributes = validator.to_h.except(:bookmarks)
+    record.attributes = data.except(:bookmarks)
     record.bookmarks_attributes = validator[:bookmarks] if validator[:bookmarks]
     record.save!
     Success(record)

--- a/spec/app/nested_has_one_form.rb
+++ b/spec/app/nested_has_one_form.rb
@@ -19,7 +19,7 @@ class NestedHasOneForm < ActiveDryForm::Form
   end
 
   action def update
-    record.attributes = validator.to_h.except(:personal_info)
+    record.attributes = data.except(:personal_info)
     record.personal_info_attributes = validator[:personal_info] if validator[:personal_info]
     record.save!
     Success(record)

--- a/spec/app/user_form.rb
+++ b/spec/app/user_form.rb
@@ -10,12 +10,12 @@ class UserForm < ActiveDryForm::Form
   end
 
   action def create
-    record = User.create!(validator.to_h)
+    record = User.create!(data)
     Success(record)
   end
 
   action def update
-    record.update!(validator.to_h)
+    record.update!(data)
     Success(record)
   end
 


### PR DESCRIPTION
1. более семантичное название
2. меньше символов
3. быстрее чем `validator.to_h` ~ 9 раз, `to_h` и другие методы идут через `method_missing` https://github.com/dry-rb/dry-validation/blob/main/lib/dry/validation/values.rb#L95 

```ruby
class NewUserContract < Dry::Validation::Contract
  schema do
    required(:payment_type).filled(:string)
    required(:first_name).filled(:string, min_size?: 2, max_size?: 100)
    required(:last_name).filled(:string, min_size?: 2, max_size?: 100)
    required(:patronymic).filled(:string, min_size?: 2, max_size?: 100)
    required(:phone).filled(:string)
    required(:street).filled(:string, min_size?: 3, max_size?: 100)
    required(:home).filled(:string, max_size?: 10)
    optional(:corpus_home).maybe(:string, max_size?: 10)
    optional(:flat).maybe(:string, max_size?: 10)
  end
end

contract = NewUserContract.new

result = contract.call(payment_type: 'payment_type', first_name: 'first_name', last_name: 'last_name',
                       patronymic: 'patronymic', phone: '+79201730729', street: 'street', home: '3')

Benchmark.ips do |x|
  x.report("to_h") { result.to_h }
  x.report("values") { result.values.to_h }
  x.report("values.data") { result.values.data }
  x.compare!
end;

# Comparison:
#          values.data: 14400679.8 i/s
#               values:  1585633.6 i/s - 9.08x  (± 0.00) slower
#                 to_h:  1550281.8 i/s - 9.29x  (± 0.00) slower

Benchmark.ips do |x|
  x.report("to_h") { result.to_h.except(:last_name) }
  x.report("values") { result.values.except(:last_name) }
  x.report("values.data") { result.values.data.except(:last_name) }
  x.compare!
end;

# Comparison:
#          values.data:  5347974.3 i/s
#               values:  3775539.5 i/s - 1.42x  (± 0.00) slower
#                 to_h:  1440918.4 i/s - 3.71x  (± 0.00) slower

```